### PR TITLE
Drop JSON dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     blurrily (0.2.1)
       activesupport
       eventmachine
-      json
 
 GEM
   remote: https://rubygems.org/
@@ -34,7 +33,6 @@ GEM
       guard (>= 1.1)
       rspec (~> 2.11)
     i18n (0.6.1)
-    json (1.7.7)
     listen (0.7.3)
     lumberjack (1.0.3)
     method_source (0.8.1)

--- a/blurrily.gemspec
+++ b/blurrily.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activesupport'
   gem.add_dependency 'eventmachine'
-  gem.add_dependency 'json'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
JSON dependency is not needed, as we don't use it anywhere.
