### PR TITLE
Bugfix: Remove reference in search tree when deleted in storage.

### DIFF
--- a/ext/blurrily/storage.c
+++ b/ext/blurrily/storage.c
@@ -605,6 +605,9 @@ int blurrily_storage_delete(trigram_map haystack, uint32_t reference)
   }
   haystack->total_trigrams -= trigrams_deleted;
   if (trigrams_deleted > 0) haystack->total_references -= 1;
+
+  if (haystack->refs) blurrily_refs_remove(haystack->refs, reference); 
+  
   return trigrams_deleted;
 }
 


### PR DESCRIPTION
Reference was never removed in search tree on deletion, so the put method returns 0 (line 408 in storage.c) when attempting to put the same reference back into the dictionary.
