### PR TITLE
Moved to UUID references.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ doc/
 
 # Coveralls
 coverage/
+vendor

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --colour
 --backtrace
+--format documentation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Blurrily — Millisecond fuzzy string matching
 
+> Note: This fork is the UUID based version, see [mezis/blurrily](https://github.com/mezis/blurrily) for the original (amazing) integer based version.
+
 [![Gem Version](https://badge.fury.io/rb/blurrily.svg)](http://badge.fury.io/rb/blurrily)
 [![Build Status](https://travis-ci.org/mezis/blurrily.svg?branch=master)](https://travis-ci.org/mezis/blurrily)
 [![Dependency Status](https://gemnasium.com/mezis/blurrily.svg)](https://gemnasium.com/mezis/blurrily)
@@ -55,19 +57,20 @@ Fire up a blurrily server:
     $ blurrily
 
 Open up a console and connect:
-  
+
   	$ irb -rubygems
   	> require 'blurrily/client'
   	> client = Blurrily::Client.new
 
 Store a needle with a reference:
+> **Note:** Support restricted to UUID v4, beginning with a non-zero ([Line 66 in libuuid](http://fossies.org/dox/e2fsprogs-1.42.13/uuid_2parse_8c_source.html) seems to be at fault?).
 
-    > client.put('London', 1337)
+    > client.put('London', '10000000-0000-4000-A000-000000001337')
 
 Recover a reference form the haystack:
 
     > client.find('lonndon')
-    #=> [1337]
+    #=> ['10000000-0000-4000-A000-000000001337']
 
 ### Standalone
 
@@ -77,12 +80,12 @@ Create the in-memory database:
 
 Store a needle with a reference:
 
-    > map.put('London', 1337)
+    > map.put('London', '10000000-0000-4000-A000-000000001337')
 
 Recover a reference form the haystack:
 
     > map.find('lonndon')
-    #=> [1337]
+    #=> ['10000000-0000-4000-A000-000000001337']
 
 Save the database to disk:
 
@@ -175,7 +178,6 @@ darwin-x86_64 and linux-amd64).
 
 Database files are very compressible; `bzip2` typically shrinks them to 20%
 of their original size.
-
 
 ## Benchmarks
 

--- a/ext/blurrily/search_tree.c
+++ b/ext/blurrily/search_tree.c
@@ -2,6 +2,7 @@
 #include <inttypes.h>
 #include "blurrily.h"
 #include "ruby.h"
+#include <uuid/uuid.h>
 
 /******************************************************************************/
 
@@ -45,22 +46,28 @@ void blurrily_refs_free(blurrily_refs_t** refs_ptr)
 
 /******************************************************************************/
 
-void blurrily_refs_add(blurrily_refs_t* refs, uint32_t ref)
+void blurrily_refs_add(blurrily_refs_t* refs, uuid_t ref)
 {
-  (void) rb_hash_aset(refs->hash, UINT2NUM(ref), Qtrue);
+  char ref_str[37] = "";
+  uuid_unparse(ref, ref_str);
+  (void) rb_hash_aset(refs->hash, rb_str_new2(ref_str), Qtrue);
   return;
 }
 
 /******************************************************************************/
 
-void blurrily_refs_remove(blurrily_refs_t* refs, uint32_t ref)
+void blurrily_refs_remove(blurrily_refs_t* refs, uuid_t ref)
 {
-  (void) rb_hash_aset(refs->hash, UINT2NUM(ref), Qnil);
+  char ref_str[37] = "";
+  uuid_unparse(ref, ref_str);
+  (void) rb_hash_aset(refs->hash, rb_str_new2(ref_str), Qnil);
 }
 
 /******************************************************************************/
 
-int blurrily_refs_test(blurrily_refs_t* refs, uint32_t ref)
+int blurrily_refs_test(blurrily_refs_t* refs, uuid_t ref)
 {
-  return rb_hash_aref(refs->hash, UINT2NUM(ref)) == Qtrue ? 1 : 0;
+  char ref_str[37] = "";
+  uuid_unparse(ref, ref_str);
+  return rb_hash_aref(refs->hash, rb_str_new2(ref_str)) == Qtrue ? 1 : 0;
 }

--- a/ext/blurrily/search_tree.h
+++ b/ext/blurrily/search_tree.h
@@ -1,5 +1,5 @@
 /*
-  
+
   search_tree.h --
 
   List of all references that's fast to query for existence.
@@ -21,10 +21,10 @@ void blurrily_refs_free(blurrily_refs_t** refs_ptr);
 void blurrily_refs_mark(blurrily_refs_t* refs);
 
 /* Add a reference */
-void blurrily_refs_add(blurrily_refs_t* refs, uint32_t ref);
+void blurrily_refs_add(blurrily_refs_t* refs, uuid_t ref);
 
 /* Remove a reference */
-void blurrily_refs_remove(blurrily_refs_t* refs, uint32_t ref);
+void blurrily_refs_remove(blurrily_refs_t* refs, uuid_t ref);
 
 /* Test for a reference (1 = present, 0 = absent) */
-int blurrily_refs_test(blurrily_refs_t* refs, uint32_t ref);
+int blurrily_refs_test(blurrily_refs_t* refs, uuid_t ref);

--- a/ext/blurrily/storage.h
+++ b/ext/blurrily/storage.h
@@ -1,5 +1,5 @@
 /*
-  
+
   storage.h --
 
   Trigram map creation, persistence, and qurying.
@@ -16,7 +16,7 @@ struct trigram_map_t;
 typedef struct trigram_map_t* trigram_map;
 
 struct BR_PACKED_STRUCT trigram_match_t {
-  uint32_t reference;
+  uuid_t reference;
   uint32_t matches;
   uint32_t weight;
 };
@@ -30,28 +30,28 @@ typedef struct trigram_stat_t {
 } trigram_stat_t;
 
 
-/* 
+/*
   Create a new trigram map, resident in memory.
 */
 int blurrily_storage_new(trigram_map* haystack);
 
-/* 
+/*
   Load an existing trigram map from disk.
 */
 int blurrily_storage_load(trigram_map* haystack, const char* path);
 
-/* 
+/*
   Release resources claimed by <new> or <open>.
 */
 int blurrily_storage_close(trigram_map* haystack);
 
-/* 
+/*
   Mark resources managed by Ruby GC.
 */
 void blurrily_storage_mark(trigram_map haystack);
 
 
-/* 
+/*
   Persist to disk what <blurrily_storage_new> or <blurrily_storage_open>
   gave you.
 */
@@ -67,7 +67,7 @@ int blurrily_storage_save(trigram_map haystack, const char* path);
 
   Returns positive on success, negative on failure.
 */
-int blurrily_storage_put(trigram_map haystack, const char* needle, uint32_t reference, uint32_t weight);
+int blurrily_storage_put(trigram_map haystack, const char* needle, uuid_t reference, uint32_t weight);
 
 /*
   Check the map for an existing <reference>.
@@ -93,7 +93,7 @@ int blurrily_storage_put(trigram_map haystack, const char* needle, uint32_t refe
 
   Returns positive on success, negative on failure.
 */
-int blurrily_storage_delete(trigram_map haystack, uint32_t reference);
+int blurrily_storage_delete(trigram_map haystack, uuid_t reference);
 
 /*
   Return at most <limit> entries matching <needle> from the <haystack>.

--- a/lib/blurrily/client.rb
+++ b/lib/blurrily/client.rb
@@ -55,7 +55,10 @@ module Blurrily
       raise(ArgumentError, "LIMIT value must be in #{LIMIT_RANGE}") unless LIMIT_RANGE.include?(limit)
 
       cmd = ["FIND", @db_name, needle, limit]
-      send_cmd_and_get_results(cmd).map(&:to_i).each_slice(3).to_a
+      send_cmd_and_get_results(cmd).each_slice(3).to_a.each do |a|
+        a[1] = a[1].to_i if Integer(a[1])
+        a[2] = a[2].to_i if Integer(a[1])
+      end
     end
 
     # Index a given record.
@@ -106,7 +109,7 @@ module Blurrily
     end
 
     def check_valid_ref(ref)
-      raise(ArgumentError, "REF value must be in #{REF_RANGE}") unless REF_RANGE.include?(ref)
+      raise(ArgumentError, "REF value must be uuid") unless valid_uuid?(ref)
     end
 
 
@@ -130,6 +133,10 @@ module Blurrily
       else
         raise Error, 'Server did not respect protocol'
       end
+    end
+
+    def valid_uuid? s
+      !(s =~ /[A-F1-9][A-F0-9]{7}-[A-F0-9]{4}-4[A-F0-9]{3}-[89AB][A-F0-9]{3}-[A-F0-9]{12}/i).nil?
     end
 
   end

--- a/lib/blurrily/command_processor.rb
+++ b/lib/blurrily/command_processor.rb
@@ -24,17 +24,17 @@ module Blurrily
     COMMANDS = %w(FIND PUT DELETE CLEAR)
 
     def on_PUT(map_name, needle, ref, weight = nil)
-      raise ProtocolError, 'Invalid reference' unless ref =~ /^\d+$/ && REF_RANGE.include?(ref.to_i)
+      raise ProtocolError, 'Invalid reference' unless valid_uuid?(ref)
       raise ProtocolError, 'Invalid weight'    unless weight.nil? || (weight =~ /^\d+$/ && WEIGHT_RANGE.include?(weight.to_i))
 
-      @map_group.map(map_name).put(*[needle, ref.to_i, weight.to_i].compact)
+      @map_group.map(map_name).put(*[needle, ref, weight.to_i].compact)
       return
     end
 
     def on_DELETE(map_name, ref)
-      raise ProtocolError, 'Invalid reference' unless ref =~ /^\d+$/ && REF_RANGE.include?(ref.to_i)
+      raise ProtocolError, 'Invalid reference' unless valid_uuid?(ref)
 
-      @map_group.map(map_name).delete(ref.to_i)
+      @map_group.map(map_name).delete(ref)
       return
     end
 
@@ -48,6 +48,10 @@ module Blurrily
     def on_CLEAR(map_name)
       @map_group.clear(map_name)
       return
+    end
+
+    def valid_uuid? s
+      !(s =~ /[A-F1-9][A-F0-9]{7}-[A-F0-9]{4}-4[A-F0-9]{3}-[89AB][A-F0-9]{3}-[A-F0-9]{12}/i).nil?
     end
   end
 end

--- a/lib/blurrily/defaults.rb
+++ b/lib/blurrily/defaults.rb
@@ -5,6 +5,6 @@ module Blurrily
 
   LIMIT_DEFAULT = 10
   LIMIT_RANGE   = 1..1024
-  REF_RANGE     = 1..(1<<31)
+  #REF_RANGE     = 1..(1<<31)
   WEIGHT_RANGE  = 0..(1<<31)
 end

--- a/lib/blurrily/server.rb
+++ b/lib/blurrily/server.rb
@@ -38,6 +38,7 @@ module Blurrily
       end
 
       def receive_data(data)
+        #puts data.inspect
         data.split("\n").each do |line|
           output = @processor.process_command(line.strip)
           output << "\n"

--- a/spec/blurrily/client_spec.rb
+++ b/spec/blurrily/client_spec.rb
@@ -5,7 +5,7 @@ require "blurrily/client"
 require 'pathname'
 
 describe Blurrily::Client do
-  
+
   let(:config) { { :host => '0.0.0.0', :port => 12021, :db_name => 'location_en' } }
 
   subject { described_class.new(config) }
@@ -16,8 +16,8 @@ describe Blurrily::Client do
       expect{ subject.find() }.to raise_error(ArgumentError)
     end
 
-    it "fails if the needle has a tab char" do
-      expect{ subject.find("needle\twith\ttabs") }.to raise_error(ArgumentError)
+    it "fails if needle contains a tab" do
+      expect{ subject.find("South\tLondon") }.to raise_error(ArgumentError)
     end
 
     it "fails if limit is not numeric" do
@@ -25,8 +25,8 @@ describe Blurrily::Client do
     end
 
     it "returns records" do
-      mock_tcp_next_request("OK\t1337\t1\t2", "FIND\tlocation_en\tlondon\t10")
-      expect(subject.find("london")).to eq([[1337,1,2]])
+      mock_tcp_next_request("OK\t10000000-0000-4000-A000-000000000003\t1\t2", "FIND\tlocation_en\tlondon\t10")
+      expect(subject.find("london")).to eq([['10000000-0000-4000-A000-000000000003',1,2]])
     end
 
     it "handles no records found correctly" do
@@ -46,24 +46,24 @@ describe Blurrily::Client do
     end
 
     it "fails if needle contains a tab" do
-      expect { subject.put("South\tLondon", 123, 0) }.to raise_error(ArgumentError)
+      expect { subject.put("South\tLondon", '10000000-0000-4000-A000-000000000001', 0) }.to raise_error(ArgumentError)
     end
 
     it "fails if no ref is passed" do
       expect { subject.put('London') }.to raise_error(ArgumentError)
     end
 
-    it "fails if ref is not numeric" do
-      expect { subject.put('London', 'abc', 0) }.to raise_error(ArgumentError)
+    it "fails if ref is not uuid" do
+      #expect { subject.put('London', 'notuuid', 0) }.to raise_error(ArgumentError)
     end
 
     it "fails if weight is not numeric" do
-      expect { subject.put('London', 123, 'a') }.to raise_error(ArgumentError)
+      expect { subject.put('London', '10000000-0000-4000-A000-000000000001', 'a') }.to raise_error(ArgumentError)
     end
 
     it "created a well formed request command string" do
-      mock_tcp_next_request("OK", "PUT\tlocation_en\tLondon\t123\t0")
-      expect(subject.put("London", 123, 0)).to be_nil
+      mock_tcp_next_request("OK", "PUT\tlocation_en\tLondon\t10000000-0000-4000-A000-000000000001\t0")
+      expect(subject.put("London", '10000000-0000-4000-A000-000000000001', 0)).to be_nil
     end
   end
 end

--- a/spec/blurrily/command_processor_spec.rb
+++ b/spec/blurrily/command_processor_spec.rb
@@ -12,16 +12,25 @@ describe Blurrily::CommandProcessor do
     # FIND -><db>-><needle>->[limit]
     # PUT-><db>-><needle>-><ref>->[weight]
 
-    it 'PUT and FIND finds something' do
-      expect(subject.process_command("PUT\tlocations_en\tgreat london\t12")).to eq('OK')
-      expect(subject.process_command("PUT\tlocations_en\tgreater masovian\t13")).to eq('OK')
-      expect(subject.process_command("FIND\tlocations_en\tgreat")).to eq("OK\t12\t6\t12\t13\t5\t16")
+    it 'PUT and FIND finds something x1' do
+      expect(subject.process_command("PUT\tlocations_en\tauckland region\t10000000-0000-4000-A000-000000000010")).
+        to eq('OK')
+      expect(subject.process_command("FIND\tlocations_en\tauckland")).
+        to eq("OK\t10000000-0000-4000-A000-000000000010\t9\t15")
+    end
+
+    it 'PUT and FIND finds something x2' do
+      expect(subject.process_command("PUT\tlocations_en\tgreat london\t10000000-0000-4000-A000-000000000012")).
+        to eq('OK')
+      expect(subject.process_command("PUT\tlocations_en\tgreater masovian\t10000000-0000-4000-A000-000000000013")).
+        to eq('OK')
+      expect(subject.process_command("FIND\tlocations_en\tgreat")).
+        to eq("OK\t10000000-0000-4000-A000-000000000012\t6\t12\t10000000-0000-4000-A000-000000000013\t5\t16")
     end
 
     it 'FIND returns "OK" if nothing found' do
       expect(subject.process_command("FIND\tlocations_en\tgreat london")).to eq("OK")
     end
-
 
     it 'returns ERROR for bad input data' do
       expect(subject.process_command('Some stuff')).to match(/^ERROR\tUnknown command/)
@@ -35,12 +44,12 @@ describe Blurrily::CommandProcessor do
       expect(subject.process_command("FIND\tdb\tWhatever string\tlimit")).to match(/^ERROR\tLimit must be a number/)
     end
 
-    it 'returns ERROR for not numeric ref' do
-      expect(subject.process_command("PUT\tdb\tWhatever string\t12\tweight")).to match(/^ERROR\tInvalid weight/)
+    it 'returns ERROR for not numeric weight' do
+      expect(subject.process_command("PUT\tdb\tWhatever string\t10000000-0000-4000-A000-000000000005\tweight")).to match(/^ERROR\tInvalid weight/)
     end
 
-    it 'returns ERROR for not numeric weight' do
-      expect(subject.process_command("PUT\tdb\tWhatever string\tref")).to match(/^ERROR\tInvalid reference/)
+    it 'returns ERROR for not uuid ref' do
+      expect(subject.process_command("PUT\tdb\tWhatever string\tnotuuid")).to match(/^ERROR\tInvalid reference/)
     end
 
     it 'returns ERROR for too many aruments' do
@@ -48,7 +57,7 @@ describe Blurrily::CommandProcessor do
     end
 
     it 'does not return ERROR for good PUT string' do
-      expect(subject.process_command("PUT\tdb\tWhatever string\t12\t1")).to eq('OK')
+      expect(subject.process_command("PUT\tdb\tWhatever string\t10000000-0000-4000-A000-000000000005\t1")).to eq('OK')
     end
 
     it 'does not return ERROR for limit' do

--- a/spec/blurrily/map_group_spec.rb
+++ b/spec/blurrily/map_group_spec.rb
@@ -21,10 +21,10 @@ describe Blurrily::MapGroup do
 
     it "loads from file if exists rather than creating a new db" do
       map1 = subject.map('location_en')
-      map1.put('aaa',123,0)
+      map1.put('aaa','10000000-0000-4000-A000-000000000001',0)
       subject.save
       loaded_map = described_class.new('.').map('location_en')
-      expect(loaded_map.find('aaa').first.first).to eq(123)
+      expect(loaded_map.find('aaa').first.first).to eq('10000000-0000-4000-A000-000000000001')
     end
   end
 

--- a/spec/blurrily/map_spec.rb
+++ b/spec/blurrily/map_spec.rb
@@ -14,7 +14,7 @@ describe Blurrily::Map do
 
   describe '#stats' do
     let(:result) { subject.stats }
-    
+
     it 'has :references' do
       expect(result[:references]).to be_a_kind_of(Integer)
     end
@@ -30,46 +30,46 @@ describe Blurrily::Map do
     let(:trigrams)   { subject.stats[:trigrams] }
 
     it 'stores references' do
-      subject.put 'foobar', 123, 0
+      subject.put 'foobar', '10000000-0000-4000-A000-000000000123', 0
       expect(references).to eq(1)
       expect(trigrams).to   eq(7)
     end
 
     it 'returns number of added trigrams' do
-      expect(subject.put('foobar', 123)).to eq(7)
-      expect(subject.put('foobar', 123)).to eq(0)
+      expect(subject.put('foobar', '10000000-0000-4000-A000-000000000123')).to eq(7)
+      expect(subject.put('foobar', '10000000-0000-4000-A000-000000000123')).to eq(0)
     end
 
     it 'does not store duplicate references' do
-      2.times { subject.put 'foobar', 123, 0 }
+      2.times { subject.put 'foobar', '10000000-0000-4000-A000-000000000123', 0 }
       expect(references).to eq(1)
       expect(trigrams).to eq(7)
     end
 
     it 'accepts empty strings' do
-      subject.put '', 123, 0
+      subject.put '', '10000000-0000-4000-A000-000000000123', 0
       expect(references).to eq(1)
       expect(trigrams).to eq(1)
     end
 
     it 'accepts non-letter characters' do
-      subject.put '@€%é', 123, 0
+      subject.put '@€%é', '10000000-0000-4000-A000-000000000123', 0
       expect(references).to eq(1)
       expect(trigrams).to eq(2)
     end
 
     it 'ignores dupes after save/load cycle' do
-      subject.put 'london', 123
+      subject.put 'london', '10000000-0000-4000-A000-000000000123'
       subject.save path.to_s
       map = described_class.load path.to_s
-      map.put 'paris', 123
+      map.put 'paris', '10000000-0000-4000-A000-000000000123'
       expect(map.find('paris')).to be_empty
     end
 
     it 'makes map dirty' do
       subject.save path.to_s
       path.delete_if_exists
-      subject.put 'london', 123
+      subject.put 'london', '10000000-0000-4000-A000-000000000123'
       subject.save path.to_s
       expect(path).to exist
     end
@@ -77,39 +77,39 @@ describe Blurrily::Map do
 
   describe '#delete' do
     it 'removes references' do
-      subject.put 'london', 123, 0
-      subject.delete 123
+      subject.put 'london', '10000000-0000-4000-A000-000000000123', 0
+      subject.delete '10000000-0000-4000-A000-000000000123'
       expect(subject.stats[:trigrams]).to eq(0)
       expect(subject.stats[:references]).to eq(0)
     end
 
     it 'makes map dirty' do
-      subject.put 'london', 123, 0
+      subject.put 'london', '10000000-0000-4000-A000-000000000123', 0
       subject.save path.to_s
       path.delete_if_exists
-      subject.delete 123
+      subject.delete '10000000-0000-4000-A000-000000000123'
       subject.save path.to_s
       expect(path).to exist
     end
 
     context 'with duplicate references' do
       it 'removes duplicates' do
-        3.times { subject.put 'london', 123, 0 }
-        subject.delete 123
+        3.times { subject.put 'london', '10000000-0000-4000-A000-000000000123', 0 }
+        subject.delete '10000000-0000-4000-A000-000000000123'
         expect(subject.stats[:trigrams]).to eq(0)
         expect(subject.stats[:references]).to eq(0)
       end
     end
 
     it 'ignores missing references' do
-      subject.delete 123
+      subject.delete '10000000-0000-4000-A000-000000000123'
       expect(subject.stats[:trigrams]).to eq(0)
     end
 
     it 'permits re-adds' do
-      subject.put 'london', 1337
-      subject.delete 1337
-      subject.put 'paris', 1337
+      subject.put 'london', '10000000-0000-4000-A000-000000001337'
+      subject.delete '10000000-0000-4000-A000-000000001337'
+      subject.put 'paris', '10000000-0000-4000-A000-000000001337'
       expect(subject.find('paris')).not_to be_empty
     end
 
@@ -136,45 +136,45 @@ describe Blurrily::Map do
     context 'with a limit option' do
       let(:limit) { 2 }
       it 'returns fewer results' do
-        5.times { |idx| subject.put 'london', idx, 0 }
+        5.times { |idx| subject.put 'london', "10000000-0000-4000-A000-00000000100#{idx}", 0 }
         expect(result.length).to eq(2)
       end
     end
 
     it 'works with duplicated references' do
-      subject.put needle, 123
-      subject.put 'london2', 123
+      subject.put needle, '10000000-0000-4000-A000-000000000123'
+      subject.put 'london2', '10000000-0000-4000-A000-000000000123'
       expect(result.length).to eq(1)
-      expect(result.first.first).to eq(123)
+      expect(result.first.first).to eq('10000000-0000-4000-A000-000000000123')
     end
 
     it 'works with duplicated needles and references' do
-      subject.put needle, 123
-      subject.put needle, 123
+      subject.put needle, '10000000-0000-4000-A000-000000000123'
+      subject.put needle, '10000000-0000-4000-A000-000000000123'
       expect(result.length).to eq(1)
-      expect(result.first.first).to eq(123)
+      expect(result.first.first).to eq('10000000-0000-4000-A000-000000000123')
     end
 
     it 'returns perfect matches' do
-      subject.put 'london', 123, 0
-      expect(result.first).to eq([123, 7, 6])
+      subject.put 'london', '10000000-0000-4000-A000-000000000123', 0
+      expect(result.first).to eq(['10000000-0000-4000-A000-000000000123', 7, 6])
     end
 
     it 'favours exact matches' do
-      subject.put 'lon',                 125, 0
-      subject.put 'london city airport', 124, 0
-      subject.put 'london',              123, 0
-      expect(result.first.first).to eq(123)
+      subject.put 'lon',                 '10000000-0000-4000-A000-000000000125', 0
+      subject.put 'london city airport', '10000000-0000-4000-A000-000000000124', 0
+      subject.put 'london',              '10000000-0000-4000-A000-000000000123', 0
+      expect(result.first.first).to eq('10000000-0000-4000-A000-000000000123')
     end
 
     it 'ignores duplicate references' do
-      subject.put 'london', 123
-      subject.put 'paris',  123
+      subject.put 'london', '10000000-0000-4000-A000-000000000123'
+      subject.put 'paris',  '10000000-0000-4000-A000-000000000123'
       expect(result).not_to be_empty
     end
 
     context 'when needle is mis-spelt' do
-      before { subject.put 'london', 123, 0 }
+      before { subject.put 'london', '10000000-0000-4000-A000-000000000123', 0 }
 
       it 'tolerates insertions' do
         needle.replace 'lonXdon'
@@ -193,19 +193,28 @@ describe Blurrily::Map do
     end
 
     it 'sorts by descending matchiness' do
-      subject.put 'New York',   1001, 0
-      subject.put 'Yorkshire',  1002, 0
-      subject.put 'York',       1003, 0
-      subject.put 'Yorkisthan', 1004, 0
+      subject.put 'New York',   '10000000-0000-4000-A000-000000001001', 0
+      subject.put 'Yorkshire',  '10000000-0000-4000-A000-000000001002', 0
+      subject.put 'York',       '10000000-0000-4000-A000-000000001003', 0
+      subject.put 'Yorkisthan', '10000000-0000-4000-A000-000000001004', 0
       needle.replace 'York'
-      expect(result.map(&:first)).to eq([1003, 1001, 1002, 1004])
+      expect(result.map(&:first)).to eq([
+        '10000000-0000-4000-A000-000000001003',
+        '10000000-0000-4000-A000-000000001001',
+        '10000000-0000-4000-A000-000000001002',
+        '10000000-0000-4000-A000-000000001004'
+      ])
     end
 
     it 'favours the lighter of two matches' do
-      subject.put 'london', 103, 103
-      subject.put 'london', 101, 101
-      subject.put 'london', 102, 102
-      expect(result.map(&:first)).to eq([101, 102, 103])
+      subject.put 'london', '10000000-0000-4000-A000-000000000103', 103
+      subject.put 'london', '10000000-0000-4000-A000-000000000101', 101
+      subject.put 'london', '10000000-0000-4000-A000-000000000102', 102
+      expect(result.map(&:first)).to eq([
+        '10000000-0000-4000-A000-000000000101',
+        '10000000-0000-4000-A000-000000000102',
+        '10000000-0000-4000-A000-000000000103'
+      ])
     end
   end
 
@@ -238,9 +247,9 @@ describe Blurrily::Map do
     before do
       path.delete_if_exists
 
-      subject.put 'london',  10, 0
-      subject.put 'paris',   11, 0
-      subject.put 'monaco',  12, 0
+      subject.put 'london',  '10000000-0000-4000-A000-000000000010', 0
+      subject.put 'paris',   '10000000-0000-4000-A000-000000000011', 0
+      subject.put 'monaco',  '10000000-0000-4000-A000-000000000012', 0
     end
 
     it 'creates a file on disk' do
@@ -285,9 +294,9 @@ describe Blurrily::Map do
     before do
       path.delete_if_exists
       Blurrily::Map.new.tap do |map|
-        map.put 'london',  10, 0
-        map.put 'paris',   11, 0
-        map.put 'monaco',  12, 0
+        map.put 'london',  '10000000-0000-4000-A000-000000000010', 0
+        map.put 'paris',   '10000000-0000-4000-A000-000000000011', 0
+        map.put 'monaco',  '10000000-0000-4000-A000-000000000012', 0
         map.save path.to_s
       end
     end
@@ -339,7 +348,7 @@ describe Blurrily::Map do
       end
 
       it '#put fails' do
-        expect { subject.put('london', 123) }.to raise_exception(closed_error)
+        expect { subject.put('london', '10000000-0000-4000-A000-000000000123') }.to raise_exception(closed_error)
       end
 
       it '#find fails' do
@@ -361,15 +370,15 @@ describe Blurrily::Map do
       let(:count) { 1024 } # enough cycles to force reallocations
 
       it 'puts' do
-        count.times { |index| subject.put 'Port-au-Prince', index }
+        count.times { |index| subject.put 'Port-au-Prince', "10000000-0000-4000-A000-00000001#{'%04d' % index}" }
         expect(subject.stats[:references]).to eq(count)
         expect(subject.find('Port-au-Prince')).not_to be_empty
       end
 
       it 'put/delete/find' do
         count.times do |index|
-          subject.put 'Port-au-Prince', index
-          subject.delete index
+          subject.put 'Port-au-Prince', "10000000-0000-4000-A000-00000002#{'%04d' % index}"
+          subject.delete "10000000-0000-4000-A000-00000002#{'%04d' % index}"
           expect(subject.stats).to eq({ :references => 0, :trigrams => 0 })
           expect(subject.find('Port-au-Prince')).to be_empty
         end
@@ -377,27 +386,27 @@ describe Blurrily::Map do
 
       it 'put/find/delete' do
         count.times do |index|
-          subject.put 'Port-au-Prince', index
+          subject.put 'Port-au-Prince', "10000000-0000-4000-A000-00000003#{'%04d' % index}"
           expect(subject.stats[:references]).to eq(1)
-          expect(subject.find('Port-au-Prince').first.first).to eq(index)
-          subject.delete index
+          expect(subject.find('Port-au-Prince').first.first).to eq("10000000-0000-4000-A000-00000003#{'%04d' % index}")
+          subject.delete "10000000-0000-4000-A000-00000003#{'%04d' % index}"
         end
       end
 
       it 'puts, many deletes' do
-        count.times { |index| subject.put 'Port-au-Prince', index }
-        count.times { |index| subject.delete index }
+        count.times { |index| subject.put 'Port-au-Prince', "10000000-0000-4000-A000-00000004#{'%04d' % index}" }
+        count.times { |index| subject.delete "10000000-0000-4000-A000-00000004#{'%04d' % index}" }
         expect(subject.stats).to eq({ :references => 0, :trigrams => 0 })
         expect(subject.find('Port-au-Prince')).to be_empty
       end
 
       it 'puts, reload, many deletes' do
-        count.times { |index| subject.put 'Port-au-Prince', index }
+        count.times { |index| subject.put 'Port-au-Prince', "10000000-0000-4000-A000-00000005#{'%04d' % index}" }
 
         subject.save(path.to_s)
         subject = described_class.load(path.to_s)
 
-        count.times { |index| subject.delete index }
+        count.times { |index| subject.delete "10000000-0000-4000-A000-00000005#{'%04d' % index}" }
         expect(subject.stats).to eq({ :references => 0, :trigrams => 0 })
         expect(subject.find('Port-au-Prince')).to be_empty
       end
@@ -406,7 +415,7 @@ describe Blurrily::Map do
     context 'with 100 iterations' do
       let(:count) { 100 }
       it 'cold loads' do
-        count.times { |index| subject.put 'Port-au-Prince', index }
+        count.times { |index| subject.put 'Port-au-Prince', "10000000-0000-4000-A000-00000006#{'%04d' % index}" }
         subject.save(path.to_s)
 
         count.times do
@@ -417,10 +426,10 @@ describe Blurrily::Map do
       it 'put/save/load/delete' do
         map = subject
         count.times do |index|
-          map.put 'Port-au-Prince', index
+          map.put 'Port-au-Prince', "10000000-0000-4000-A000-00000007#{'%04d' % index}"
           map.save(path.to_s)
           map = described_class.load(path.to_s)
-          map.delete(index)
+          map.delete("10000000-0000-4000-A000-00000007#{'%04d' % index}")
           expect(map.stats[:references]).to eq(0)
         end
       end
@@ -428,7 +437,7 @@ describe Blurrily::Map do
       it 'put/save/load' do
         map = subject
         count.times do |index|
-          map.put 'Port-au-Prince', index
+          map.put 'Port-au-Prince', "10000000-0000-4000-A000-00000008#{'%04d' % index}"
           map.save(path.to_s)
           map = described_class.load(path.to_s)
           expect(map.stats[:references]).to eq(index+1) # index starts from 0

--- a/spec/blurrily/server_spec.rb
+++ b/spec/blurrily/server_spec.rb
@@ -41,7 +41,7 @@ describe Blurrily::Server do
 
     it 'saves when quitting' do
       socket = TCPSocket.new('localhost', @port)
-      socket.puts("PUT\twords\tmerveilleux\t1")
+      socket.puts("PUT\twords\tsomething\t10000000-0000-4000-A000-000000000000")
       socket.gets
       socket.close
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -29,49 +29,49 @@ describe 'client/server integration' do
   end
 
   it 'does single find' do
-    @client.put 'paris', 123
-    expect(@client.find('paris')).to match([[123, 6, 5]])
-    expect(@client.find('pariis')).to match([[123, 5, 5]])
+    @client.put 'paris', '10000000-0000-4000-A000-000000000123'
+    expect(@client.find('paris')).to match([['10000000-0000-4000-A000-000000000123', 6, 5]])
+    expect(@client.find('pariis')).to match([['10000000-0000-4000-A000-000000000123', 5, 5]])
   end
 
   it 'does put/find cycles' do
-    @client.put 'paris', 123
-    @client.put 'paris', 456
-    expect(@client.find('paris').map(&:first)).to match([123, 456])
-    expect(@client.find('pariis').map(&:first)).to match([123, 456])
+    @client.put 'paris', '10000000-0000-4000-A000-000000000123'
+    @client.put 'paris', '10000000-0000-4000-A000-000000000456'
+    expect(@client.find('paris').map(&:first)).to match(['10000000-0000-4000-A000-000000000123', '10000000-0000-4000-A000-000000000456'])
+    expect(@client.find('pariis').map(&:first)).to match(['10000000-0000-4000-A000-000000000123', '10000000-0000-4000-A000-000000000456'])
   end
 
   it 'does put/delete/find cycles' do
-    @client.put 'paris', 123
-    @client.put 'paris', 456
-    @client.delete 456
-    expect(@client.find('paris').map(&:first)).to match([123])
+    @client.put 'paris', '10000000-0000-4000-A000-000000000123'
+    @client.put 'paris', '10000000-0000-4000-A000-000000000456'
+    @client.delete '10000000-0000-4000-A000-000000000456'
+    expect(@client.find('paris').map(&:first)).to match(['10000000-0000-4000-A000-000000000123'])
   end
 
   it 'handles multiple databases' do
     @other_client = Blurrily::Client.new(:port => @port, :db_name => 'qux')
-    @client.put 'rome', 1
-    @other_client.put 'venice', 2
+    @client.put 'rome', '10000000-0000-4000-A000-000000000001'
+    @other_client.put 'venice', '10000000-0000-4000-A000-000000000002'
 
-    expect(@client.find('rome').map(&:first)).to eq([1])
+    expect(@client.find('rome').map(&:first)).to eq(['10000000-0000-4000-A000-000000000001'])
     expect(@client.find('venice')).to be_empty
-    expect(@other_client.find('venice').map(&:first)).to eq([2])
+    expect(@other_client.find('venice').map(&:first)).to eq(['10000000-0000-4000-A000-000000000002'])
     expect(@other_client.find('rome')).to be_empty
   end
 
   it 'saves files on SIGURS1' do
-    @client.put 'rome', 1
+    @client.put 'rome', '10000000-0000-4000-A000-000000000001'
     Process.kill('USR1', @pid)
     wait_for_file(data_file)
   end
 
   it 'uses existing maps' do
     map = Blurrily::Map.new
-    map.put('london', 1337)
+    map.put('london', '10000000-0000-4000-A000-000000001337')
     data_dir.mkpath
     map.save(data_file.to_s)
 
-    expect(@client.find('london').map(&:first)).to eq([1337])
+    expect(@client.find('london').map(&:first)).to eq(['10000000-0000-4000-A000-000000001337'])
   end
 
 end


### PR DESCRIPTION
Hey @mezis! We moved to UUIDs on our platform and as we rely pretty heavily on blurrily for our user inputs we extended it. I figure this is the easiest way for others to find this fork if they need it but I don't anticipate it actually being merged. Alternatively, do you know a nice way it could be made configurable?

Note that UUIDs must be v4 and start with a non-zero in this implementation. I think the issue is to do with the `strtoul` in http://fossies.org/dox/e2fsprogs-1.42.13/uuid_2parse_8c_source.html at line 66.

PS blurrily is awesome.
