### PR TITLE
Add Ruby 2.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
+before_install:
+  - gem install bundler
 rvm:
   - "1.9.3"
   - "2.0.0"
   - "2.1.5"
   - "2.2.0"
+  - "2.3.1"
+  - "2.4.0"
 # increment to force build: 001

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
       thor (= 0.18.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    eventmachine (1.0.4)
+    eventmachine (1.2.2)
     ffi (1.9.6)
     formatador (0.2.5)
     guard (2.11.1)
@@ -45,7 +45,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     hitimes (1.2.2)
     i18n (0.7.0)
-    json (1.8.2)
+    json (1.8.6)
     listen (2.8.5)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
@@ -126,3 +126,6 @@ DEPENDENCIES
   rb-fsevent
   rspec
   terminal-notifier-guard
+
+BUNDLED WITH
+   1.14.3

--- a/ext/blurrily/extconf.rb
+++ b/ext/blurrily/extconf.rb
@@ -1,7 +1,7 @@
 require 'mkmf'
 
 PLATFORM = `uname`.strip.upcase
-SHARED_FLAGS = "-DPLATFORM_#{PLATFORM} --std=c99 -Wall -Wextra -Werror"
+SHARED_FLAGS = "-DPLATFORM_#{PLATFORM} --std=c99 -Wall -Wextra"
 
 case PLATFORM
 when 'LINUX'


### PR DESCRIPTION
https://github.com/mezis/blurrily/issues/46

I dug around and think found the issue.

`-Werror` makes all warning fatal during compilation, and for some reason unused argument warnings started appearing with Ruby 2.4.

The tests pass on my machine.